### PR TITLE
Add HybridTSS inference-only mode and move helpers to scripts

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -20,7 +20,7 @@ jobs:
           version: "latest"
 
       - name: Generate 1k test data (rules=1000, packets=10000)
-        run: uv run gen_testdata.py --rules 1000 --packets 10000 --seed 42 --out-dir Data
+        run: uv run scripts/gen_testdata.py --rules 1000 --packets 10000 --seed 42 --out-dir Data
 
       - name: Build
         run: make

--- a/HybridTSS/HybridTSS.cpp
+++ b/HybridTSS/HybridTSS.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <algorithm>
 #include <cstring>
+#include <stdexcept>
 
 using namespace std;
 
@@ -15,6 +16,24 @@ using namespace std;
 namespace {
 constexpr char kQTableMagic[4] = {'H', 'T', 'Q', '1'};
 constexpr uint32_t kQTableVersion = 1;
+constexpr int kMinQTableBits = 1;
+constexpr int kMaxQTableBits = 30;
+
+bool ValidateQTableBits(const HybridOptions& opts, string* err) {
+    if (opts.state_bits < kMinQTableBits || opts.state_bits > kMaxQTableBits) {
+        if (err) {
+            *err = "ht-state-bits must be in [1, 30]";
+        }
+        return false;
+    }
+    if (opts.action_bits < kMinQTableBits || opts.action_bits > kMaxQTableBits) {
+        if (err) {
+            *err = "ht-action-bits must be in [1, 30]";
+        }
+        return false;
+    }
+    return true;
+}
 }
 
 
@@ -38,7 +57,13 @@ HybridTSS::~HybridTSS() {
 // To-do: 结构过于冗余，待抽象根据QTable构建Classifier代码
 // -----------------------------------------------------------------------------
 void HybridTSS::ConstructClassifier(const vector<Rule> &rules) {
-    ConstructClassifierSafe(rules, nullptr);
+    string err;
+    if (!ConstructClassifierSafe(rules, &err)) {
+        if (last_error_.empty()) {
+            last_error_ = err.empty() ? "failed to construct HybridTSS" : err;
+        }
+        cerr << "Failed to construct HybridTSS: " << last_error_ << endl;
+    }
 }
 
 bool HybridTSS::ConstructClassifierSafe(const vector<Rule> &rules, string* err) {
@@ -64,6 +89,15 @@ bool HybridTSS::ConstructClassifierSafe(const vector<Rule> &rules, string* err) 
 }
 
 bool HybridTSS::prepareQTable(const vector<Rule>& rules, string* err) {
+    string bitErr;
+    if (!ValidateQTableBits(options, &bitErr)) {
+        last_error_ = bitErr;
+        if (err) {
+            *err = last_error_;
+        }
+        return false;
+    }
+
     if (options.train_online) {
         train(rules);
         qtable_loaded_ = true;
@@ -295,6 +329,15 @@ bool HybridTSS::SaveQTable(const string& path, string* err) const {
 }
 
 bool HybridTSS::LoadQTable(const string& path, string* err) {
+    string bitErr;
+    if (!ValidateQTableBits(options, &bitErr)) {
+        last_error_ = bitErr;
+        if (err) {
+            *err = last_error_;
+        }
+        return false;
+    }
+
     ifstream in(path, ios::binary);
     if (!in.is_open()) {
         last_error_ = "failed to open QTable input file: " + path;
@@ -347,8 +390,8 @@ bool HybridTSS::LoadQTable(const string& path, string* err) {
         return false;
     }
 
-    const uint32_t expectedRows = static_cast<uint32_t>(1u << options.state_bits);
-    const uint32_t expectedCols = static_cast<uint32_t>(1u << options.action_bits);
+    const uint32_t expectedRows = static_cast<uint32_t>(uint64_t{1} << options.state_bits);
+    const uint32_t expectedCols = static_cast<uint32_t>(uint64_t{1} << options.action_bits);
     if (rows != expectedRows || cols != expectedCols) {
         last_error_ = "QTable dimensions mismatch with state/action bits";
         if (err) {
@@ -549,10 +592,15 @@ inline int key_action(Key k) { return static_cast<int>(k & 0x3F); }
 // ------------------------------------------------------------
 void HybridTSS::train(const vector<Rule> &rules) {
 
+    string bitErr;
+    if (!ValidateQTableBits(options, &bitErr)) {
+        throw std::invalid_argument(bitErr);
+    }
+
     cout << "Starting parallel training with " << omp_get_max_threads() << " threads..." << endl;
 
-    const int stateSize = 1 << options.state_bits;
-    const int actionSize = 1 << options.action_bits;
+    const size_t stateSize = size_t{1} << options.state_bits;
+    const size_t actionSize = size_t{1} << options.action_bits;
     const int loopNum = options.loop_num;      // 減少以便測試
     const int progressStep = options.progress_step;
     const double lr = options.lr;         // 初始 learning rate

--- a/HybridTSS/HybridTSS.cpp
+++ b/HybridTSS/HybridTSS.cpp
@@ -2,6 +2,7 @@
 #include <omp.h>
 #include <atomic>
 #include <algorithm>
+#include <cstring>
 
 using namespace std;
 
@@ -11,8 +12,19 @@ using namespace std;
 #include <fstream>
 #include <iomanip>
 
+namespace {
+constexpr char kQTableMagic[4] = {'H', 'T', 'Q', '1'};
+constexpr uint32_t kQTableVersion = 1;
+}
 
-HybridTSS::HybridTSS(const HybridOptions& opts) : options(opts), binth(opts.binth), root(nullptr), rtssleaf(opts.rtssleaf) {
+
+HybridTSS::HybridTSS(const HybridOptions& opts)
+    : options(opts),
+      binth(opts.binth),
+      root(nullptr),
+      rtssleaf(opts.rtssleaf),
+      qtable_loaded_(false),
+      last_error_() {
 }
 
 HybridTSS::~HybridTSS() {
@@ -26,7 +38,59 @@ HybridTSS::~HybridTSS() {
 // To-do: 结构过于冗余，待抽象根据QTable构建Classifier代码
 // -----------------------------------------------------------------------------
 void HybridTSS::ConstructClassifier(const vector<Rule> &rules) {
-    train(rules);
+    ConstructClassifierSafe(rules, nullptr);
+}
+
+bool HybridTSS::ConstructClassifierSafe(const vector<Rule> &rules, string* err) {
+    delete root;
+    root = nullptr;
+    qtable_loaded_ = false;
+    last_error_.clear();
+
+    if (!prepareQTable(rules, err)) {
+        return false;
+    }
+
+    buildTreeFromQTable(rules);
+
+    if (!root) {
+        last_error_ = "failed to build HybridTSS tree";
+        if (err) {
+            *err = last_error_;
+        }
+        return false;
+    }
+    return true;
+}
+
+bool HybridTSS::prepareQTable(const vector<Rule>& rules, string* err) {
+    if (options.train_online) {
+        train(rules);
+        qtable_loaded_ = true;
+        if (!options.qtable_out_path.empty()) {
+            string saveErr;
+            if (!SaveQTable(options.qtable_out_path, &saveErr)) {
+                last_error_ = saveErr;
+                if (err) {
+                    *err = last_error_;
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    if (options.qtable_in_path.empty()) {
+        last_error_ = "inference-only mode requires --ht-qtable-in";
+        if (err) {
+            *err = last_error_;
+        }
+        return false;
+    }
+    return LoadQTable(options.qtable_in_path, err);
+}
+
+void HybridTSS::buildTreeFromQTable(const vector<Rule>& rules) {
 
     root = new SubHybridTSS(rules, options.hash_inflation);
     queue<SubHybridTSS*> que;
@@ -105,6 +169,9 @@ void HybridTSS::ConstructClassifier(const vector<Rule> &rules) {
 // To-do:
 // -----------------------------------------------------------------------------
 int HybridTSS::ClassifyAPacket(const Packet &packet) {
+    if (!root) {
+        return -1;
+    }
     return root->ClassifyAPacket(packet);
 }
 
@@ -114,7 +181,9 @@ int HybridTSS::ClassifyAPacket(const Packet &packet) {
 // To-do:
 // -----------------------------------------------------------------------------
 void HybridTSS::DeleteRule(const Rule &rule) {
-    root->DeleteRule(rule);
+    if (root) {
+        root->DeleteRule(rule);
+    }
 }
 
 
@@ -124,7 +193,9 @@ void HybridTSS::DeleteRule(const Rule &rule) {
 // To-do:
 // -----------------------------------------------------------------------------
 void HybridTSS::InsertRule(const Rule &rule) {
-    root->InsertRule(rule);
+    if (root) {
+        root->InsertRule(rule);
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -133,6 +204,9 @@ void HybridTSS::InsertRule(const Rule &rule) {
 // To-do:
 // -----------------------------------------------------------------------------
 Memory HybridTSS::MemSizeBytes() const {
+    if (!root) {
+        return 0;
+    }
     return root->MemSizeBytes();
 }
 
@@ -161,6 +235,144 @@ size_t HybridTSS::NumTables() const {
 // -----------------------------------------------------------------------------
 size_t HybridTSS::RulesInTable(size_t tableIndex) const {
     return 0;
+}
+
+bool HybridTSS::IsReady() const {
+    return root != nullptr && qtable_loaded_;
+}
+
+const string& HybridTSS::LastError() const {
+    return last_error_;
+}
+
+bool HybridTSS::SaveQTable(const string& path, string* err) const {
+    if (QTable.empty() || QTable[0].empty()) {
+        if (err) {
+            *err = "QTable is empty; nothing to save";
+        }
+        return false;
+    }
+
+    const uint32_t rows = static_cast<uint32_t>(QTable.size());
+    const uint32_t cols = static_cast<uint32_t>(QTable[0].size());
+    for (const auto& row : QTable) {
+        if (row.size() != cols) {
+            if (err) {
+                *err = "QTable rows have inconsistent sizes";
+            }
+            return false;
+        }
+    }
+
+    ofstream out(path, ios::binary | ios::trunc);
+    if (!out.is_open()) {
+        if (err) {
+            *err = "failed to open QTable output file: " + path;
+        }
+        return false;
+    }
+
+    const uint32_t stateBits = static_cast<uint32_t>(options.state_bits);
+    const uint32_t actionBits = static_cast<uint32_t>(options.action_bits);
+
+    out.write(kQTableMagic, sizeof(kQTableMagic));
+    out.write(reinterpret_cast<const char*>(&kQTableVersion), sizeof(kQTableVersion));
+    out.write(reinterpret_cast<const char*>(&stateBits), sizeof(stateBits));
+    out.write(reinterpret_cast<const char*>(&actionBits), sizeof(actionBits));
+    out.write(reinterpret_cast<const char*>(&rows), sizeof(rows));
+    out.write(reinterpret_cast<const char*>(&cols), sizeof(cols));
+    for (const auto& row : QTable) {
+        out.write(reinterpret_cast<const char*>(row.data()), static_cast<std::streamsize>(row.size() * sizeof(double)));
+    }
+
+    if (!out.good()) {
+        if (err) {
+            *err = "failed while writing QTable file: " + path;
+        }
+        return false;
+    }
+    return true;
+}
+
+bool HybridTSS::LoadQTable(const string& path, string* err) {
+    ifstream in(path, ios::binary);
+    if (!in.is_open()) {
+        last_error_ = "failed to open QTable input file: " + path;
+        if (err) {
+            *err = last_error_;
+        }
+        return false;
+    }
+
+    char magic[4] = {0, 0, 0, 0};
+    uint32_t version = 0;
+    uint32_t stateBits = 0;
+    uint32_t actionBits = 0;
+    uint32_t rows = 0;
+    uint32_t cols = 0;
+
+    in.read(magic, sizeof(magic));
+    in.read(reinterpret_cast<char*>(&version), sizeof(version));
+    in.read(reinterpret_cast<char*>(&stateBits), sizeof(stateBits));
+    in.read(reinterpret_cast<char*>(&actionBits), sizeof(actionBits));
+    in.read(reinterpret_cast<char*>(&rows), sizeof(rows));
+    in.read(reinterpret_cast<char*>(&cols), sizeof(cols));
+
+    if (!in.good()) {
+        last_error_ = "invalid QTable header: " + path;
+        if (err) {
+            *err = last_error_;
+        }
+        return false;
+    }
+    if (memcmp(magic, kQTableMagic, sizeof(magic)) != 0) {
+        last_error_ = "QTable magic mismatch: " + path;
+        if (err) {
+            *err = last_error_;
+        }
+        return false;
+    }
+    if (version != kQTableVersion) {
+        last_error_ = "QTable version mismatch";
+        if (err) {
+            *err = last_error_;
+        }
+        return false;
+    }
+    if (stateBits != static_cast<uint32_t>(options.state_bits) || actionBits != static_cast<uint32_t>(options.action_bits)) {
+        last_error_ = "QTable bits mismatch with current HybridOptions";
+        if (err) {
+            *err = last_error_;
+        }
+        return false;
+    }
+
+    const uint32_t expectedRows = static_cast<uint32_t>(1u << options.state_bits);
+    const uint32_t expectedCols = static_cast<uint32_t>(1u << options.action_bits);
+    if (rows != expectedRows || cols != expectedCols) {
+        last_error_ = "QTable dimensions mismatch with state/action bits";
+        if (err) {
+            *err = last_error_;
+        }
+        return false;
+    }
+
+    vector<vector<double>> loaded(rows, vector<double>(cols, 0.0));
+    for (uint32_t r = 0; r < rows; ++r) {
+        in.read(reinterpret_cast<char*>(loaded[r].data()), static_cast<std::streamsize>(cols * sizeof(double)));
+        if (!in.good()) {
+            last_error_ = "QTable payload truncated: " + path;
+            if (err) {
+                *err = last_error_;
+            }
+            return false;
+        }
+    }
+
+    QTable.swap(loaded);
+    qtable_loaded_ = true;
+    last_error_.clear();
+    return true;
 }
 
 // -----------------------------------------------------------------------------
@@ -260,7 +472,7 @@ vector<int> HybridTSS::getAction(SubHybridTSS *state, int epsilion) {
 // To-do:
 // -----------------------------------------------------------------------------
 void HybridTSS::ConstructBaseline(const vector<Rule> &rules) {
-    root = new SubHybridTSS(rules);
+    root = new SubHybridTSS(rules, options.hash_inflation);
     root->nodeId = 0;
     queue<SubHybridTSS*> que;
     que.push(root);

--- a/HybridTSS/HybridTSS.h
+++ b/HybridTSS/HybridTSS.h
@@ -2,6 +2,7 @@
 #define HYBRIDTSSV1_2_HYBRIDTSS_H
 #include "SubHybridTSS.h"
 #include <cstdint>
+#include <string>
 
 struct HybridOptions {
     int binth = 8;              // linear search threshold
@@ -17,6 +18,9 @@ struct HybridOptions {
     int progress_step = 10;     // progress print step (%), used in DEBUG
     int hash_inflation = 10;    // hash table inflation factor in SubHybridTSS
     uint64_t seed = 0;          // optional seed for training RNG (0 => time-based)
+    bool train_online = true;   // true: train in ConstructClassifier, false: require pre-trained QTable
+    std::string qtable_in_path; // optional input path for pre-trained QTable
+    std::string qtable_out_path; // optional output path to persist trained QTable
 };
 
 class HybridTSS : public PacketClassifier {
@@ -31,6 +35,12 @@ public:
     HybridTSS& operator=(HybridTSS&&) = delete;
 
     void ConstructClassifier(const std::vector<Rule> &rules) override;
+    bool ConstructClassifierSafe(const std::vector<Rule> &rules, std::string* err = nullptr);
+
+    bool LoadQTable(const std::string& path, std::string* err = nullptr);
+    bool SaveQTable(const std::string& path, std::string* err = nullptr) const;
+    bool IsReady() const;
+    const std::string& LastError() const;
 
     int ClassifyAPacket(const Packet& packet) override;
     void DeleteRule(const Rule& rule) override;
@@ -58,6 +68,11 @@ private:
     SubHybridTSS *root;
     double rtssleaf;
     std::vector<std::vector<double> > QTable;
+    bool qtable_loaded_;
+    std::string last_error_;
+
+    bool prepareQTable(const std::vector<Rule>& rules, std::string* err);
+    void buildTreeFromQTable(const std::vector<Rule>& rules);
 
     void train(const std::vector<Rule> &rules);
 };

--- a/RUN.md
+++ b/RUN.md
@@ -24,6 +24,12 @@ Example:
 ./main -r ./Data/acl1_1k -p ./Data/acl1_1k_trace
 ```
 
+## Generate test data
+
+```bash
+uv run scripts/gen_testdata.py --rules 1000 --packets 10000 --seed 42 --out-dir Data
+```
+
 ## HybridTSS model workflow (train once, infer many)
 
 ### 1) Train and export QTable

--- a/RUN.md
+++ b/RUN.md
@@ -24,6 +24,28 @@ Example:
 ./main -r ./Data/acl1_1k -p ./Data/acl1_1k_trace
 ```
 
+## HybridTSS model workflow (train once, infer many)
+
+### 1) Train and export QTable
+
+```bash
+./main -r ./Data/acl1_1k -p ./Data/acl1_1k_trace \
+  --classifier hybrid \
+  --ht-train-online 1 \
+  --ht-qtable-out ./Data/hybrid_acl1_1k.qtable
+```
+
+### 2) Inference-only (no online training)
+
+```bash
+./main -r ./Data/acl1_1k -p ./Data/acl1_1k_trace \
+  --classifier hybrid \
+  --ht-train-online 0 \
+  --ht-qtable-in ./Data/hybrid_acl1_1k.qtable
+```
+
+If `--ht-train-online 0` is used without `--ht-qtable-in`, the run fails fast with an explicit error.
+
 ## Lint
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -58,6 +58,14 @@
 - [ ] Decide update model: RCU swap (new instance build + pointer flip) and/or per-PMD instances; keep EMC behavior unchanged
 - [ ] Scope support matrix: IPv4 5-tuple + proto mask 0/0xFF only; unknown fields fall back to native dpcls
 
+### Dataplane Readiness (OVS netdev userspace)
+- [x] Split training from inference path: `ConstructClassifierSafe()` now supports inference-only mode (`train_online=false`) with fail-fast behavior when no model is provided
+- [x] Add model artifact workflow: `SaveQTable`/`LoadQTable` with versioned binary format (`HTQ1`)
+- [x] Add immutable runtime engine API hooks for fast path (`ConstructClassifierSafe`, `IsReady`, `LastError`) and explicit not-ready behavior
+- [ ] Replace packet hot-path `std::vector` representation with fixed-size `PacketKey` struct for cache-friendly lookups
+- [ ] Define OVS PoC acceptance criteria: correctness parity vs native dpcls, throughput, p99 latency, update stall time
+- [ ] Add fallback policy: unsupported match fields automatically route to native dpcls backend
+
 ### HybridTSS Configurability
 - [x] Introduce `HybridOptions` to hold tunables (binth, rtssleaf, loop_num, lr, decay, epsilons, state/action bits, seed, inflation)
 - [x] Plumb options from CLI/config into HybridTSS; keep current hardcoded defaults when unspecified
@@ -67,10 +75,20 @@
 - [x] Add CLI flags: classifiers selection, trials, run/skip updates, seed, metrics path (append/overwrite)
 - [ ] Isolate state: rebuild or copy before updates so runs don’t contaminate each other
 - [x] Replace global randomness with mt19937_64 seeded from CLI; generate update sequence once per run
+- [x] Add HybridTSS model-mode CLI flags and validation: `--ht-train-online`, `--ht-qtable-in`, `--ht-qtable-out`
+
+### Testing
+- [x] Add inference-only failure-path test (no QTable input)
+- [x] Add train-save-load QTable roundtrip test for HybridTSS
 
 ### Observability
 - [ ] Define stats to expose (hit/miss, tuple/table counts, rules, build/training time, memory footprint, update latency)
 - [ ] Add lightweight per-PMD counters and unixctl/ovs-appctl dump format (no hot-path logging)
+
+### Dataset Toolchain
+- [ ] Evaluate and fork maintained dataset generator (`classbench-ng`) for long-term reproducibility
+- [ ] Add dataset manifest (seed, count, generator commit, checksum) and enforce it in CI
+- [ ] Keep local `gen_testdata.py` as a quick smoke-data generator; use ClassBench-ng datasets for reported benchmarks
 
 ## Not Addressed — Known Pre-existing Issues
 

--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@
   - [x] Extend metrics with HybridTSS configuration values for reproducibility
 
 ### Testing
-- [x] Create `gen_testdata.py` — generates ClassBench-format rules + matching packet traces
+- [x] Create `scripts/gen_testdata.py` — generates ClassBench-format rules + matching packet traces
 - [x] Generate test data — `Data/test_100` (100 rules), `Data/test_100_trace` (1000 packets)
 - [x] Verify all 3 classifiers (PSTSS, CutTSS, HybridTSS) produce correct results with generated data
 
@@ -88,7 +88,7 @@
 ### Dataset Toolchain
 - [ ] Evaluate and fork maintained dataset generator (`classbench-ng`) for long-term reproducibility
 - [ ] Add dataset manifest (seed, count, generator commit, checksum) and enforce it in CI
-- [ ] Keep local `gen_testdata.py` as a quick smoke-data generator; use ClassBench-ng datasets for reported benchmarks
+- [ ] Keep local `scripts/gen_testdata.py` as a quick smoke-data generator; use ClassBench-ng datasets for reported benchmarks
 
 ## Not Addressed — Known Pre-existing Issues
 
@@ -114,6 +114,6 @@ The OVS `cmap` code uses C-style `malloc`/`free`/`memset` to manage memory conta
 - `README.md`, `RUN.md`
 
 **Created files:**
-- `TODO.md`, `gen_testdata.py`
+- `TODO.md`, `scripts/gen_testdata.py`
 - `Data/test_100`, `Data/test_100_trace`
 - `results.csv` (benchmark output)

--- a/cli.cpp
+++ b/cli.cpp
@@ -1,5 +1,6 @@
 #include "cli.h"
 
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <unordered_set>
@@ -38,7 +39,10 @@ void usage(const char* prog) {
          << "  --ht-state-bits <int>       HybridTSS state bits (default 20)\n"
          << "  --ht-action-bits <int>      HybridTSS action bits (default 6)\n"
          << "  --ht-hash-inflation <int>   HybridTSS hash inflation (default 10)\n"
-         << "  --ht-seed <u64>             HybridTSS training seed (0 => time-based)\n";
+         << "  --ht-seed <u64>             HybridTSS training seed (0 => time-based)\n"
+         << "  --ht-train-online <0|1>     HybridTSS train during construct (default 1)\n"
+         << "  --ht-qtable-in <path>       HybridTSS QTable input for inference-only\n"
+         << "  --ht-qtable-out <path>      HybridTSS QTable output after training\n";
 }
 
 bool parse_args(int argc, char* argv[], Options& opts) {
@@ -158,6 +162,23 @@ bool parse_args(int argc, char* argv[], Options& opts) {
             } catch (const std::exception&) {
                 cerr << "--ht-seed requires an integer" << endl; return false;
             }
+        } else if (arg == "--ht-train-online") {
+            if (i + 1 >= argc) { cerr << "--ht-train-online requires 0 or 1" << endl; return false; }
+            string value = argv[++i];
+            if (value == "0") {
+                opts.hybrid_opts.train_online = false;
+            } else if (value == "1") {
+                opts.hybrid_opts.train_online = true;
+            } else {
+                cerr << "--ht-train-online expects 0 or 1" << endl;
+                return false;
+            }
+        } else if (arg == "--ht-qtable-in") {
+            if (i + 1 >= argc) { cerr << "--ht-qtable-in requires a value" << endl; return false; }
+            opts.hybrid_opts.qtable_in_path = argv[++i];
+        } else if (arg == "--ht-qtable-out") {
+            if (i + 1 >= argc) { cerr << "--ht-qtable-out requires a value" << endl; return false; }
+            opts.hybrid_opts.qtable_out_path = argv[++i];
         } else {
             cerr << "Unknown argument: " << arg << endl;
             return false;
@@ -170,6 +191,12 @@ bool parse_args(int argc, char* argv[], Options& opts) {
 
     if (opts.classifiers.empty()) {
         opts.classifiers = {"pstss", "cuttss", "hybrid"};
+    }
+
+    const bool runHybrid = std::find(opts.classifiers.begin(), opts.classifiers.end(), "hybrid") != opts.classifiers.end();
+    if (runHybrid && !opts.hybrid_opts.train_online && opts.hybrid_opts.qtable_in_path.empty()) {
+        cerr << "--ht-train-online 0 requires --ht-qtable-in <path>" << endl;
+        return false;
     }
 
     // de-duplicate

--- a/cli.cpp
+++ b/cli.cpp
@@ -7,6 +7,11 @@
 
 using namespace std;
 
+namespace {
+constexpr int kMinQTableBits = 1;
+constexpr int kMaxQTableBits = 30;
+}
+
 vector<string> split(const string& s, char delim) {
     vector<string> out;
     string item;
@@ -194,6 +199,14 @@ bool parse_args(int argc, char* argv[], Options& opts) {
     }
 
     const bool runHybrid = std::find(opts.classifiers.begin(), opts.classifiers.end(), "hybrid") != opts.classifiers.end();
+    if (runHybrid && (opts.hybrid_opts.state_bits < kMinQTableBits || opts.hybrid_opts.state_bits > kMaxQTableBits)) {
+        cerr << "--ht-state-bits must be in [1, 30]" << endl;
+        return false;
+    }
+    if (runHybrid && (opts.hybrid_opts.action_bits < kMinQTableBits || opts.hybrid_opts.action_bits > kMaxQTableBits)) {
+        cerr << "--ht-action-bits must be in [1, 30]" << endl;
+        return false;
+    }
     if (runHybrid && !opts.hybrid_opts.train_online && opts.hybrid_opts.qtable_in_path.empty()) {
         cerr << "--ht-train-online 0 requires --ht-qtable-in <path>" << endl;
         return false;

--- a/main.cpp
+++ b/main.cpp
@@ -193,6 +193,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    bool hasFailures = false;
     for (const auto& clf : opts.classifiers) {
         // fresh update plan per classifier run to avoid cross-run mutation
         randUpdate.clear();
@@ -207,18 +208,25 @@ int main(int argc, char* argv[]) {
 
         if (clf == "pstss") {
             PacketClassifier *PSTSS = new PriorityTupleSpaceSearch();
-            testPerformance(PSTSS, opts, randUpdate, false);
+            if (!testPerformance(PSTSS, opts, randUpdate, false)) {
+                hasFailures = true;
+            }
             delete PSTSS;
         } else if (clf == "cuttss") {
             PacketClassifier *CT = new CutTSS();
-            testPerformance(CT, opts, randUpdate, false);
+            if (!testPerformance(CT, opts, randUpdate, false)) {
+                hasFailures = true;
+            }
             delete CT;
         } else if (clf == "hybrid") {
             PacketClassifier *HT = new HybridTSS(opts.hybrid_opts);
-            testPerformance(HT, opts, randUpdate, true);
+            if (!testPerformance(HT, opts, randUpdate, true)) {
+                hasFailures = true;
+            }
             delete HT;
         } else {
             cerr << "Unknown classifier name: " << clf << endl;
+            hasFailures = true;
         }
     }
 
@@ -226,5 +234,5 @@ int main(int argc, char* argv[]) {
         fMetrics.close();
     }
 
-    return 0;
+    return hasFailures ? 1 : 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -25,10 +25,23 @@ ofstream fError("ErrorLog.csv", ios::app);
 ofstream fMetrics;  // CSV metrics output
 
 
-void testPerformance(PacketClassifier *p, const Options& opts, const vector<int>& updatePlan, bool isHybrid) {
+bool testPerformance(PacketClassifier *p, const Options& opts, const vector<int>& updatePlan, bool isHybrid) {
     cout << p->funName() << ":" << endl;
     Start = std::chrono::steady_clock::now();
-    p->ConstructClassifier(rules);
+    if (isHybrid) {
+        auto* hybrid = dynamic_cast<HybridTSS*>(p);
+        if (!hybrid) {
+            cerr << "Internal error: expected HybridTSS instance" << endl;
+            return false;
+        }
+        string err;
+        if (!hybrid->ConstructClassifierSafe(rules, &err)) {
+            cerr << "Failed to construct HybridTSS: " << err << endl;
+            return false;
+        }
+    } else {
+        p->ConstructClassifier(rules);
+    }
     End = std::chrono::steady_clock::now();
     elapsed_milliseconds = End - Start;
     double constructTime = elapsed_milliseconds.count();
@@ -127,6 +140,7 @@ void testPerformance(PacketClassifier *p, const Options& opts, const vector<int>
         }
         fMetrics << "\n";
     }
+    return true;
 }
 
 int main(int argc, char* argv[]) {

--- a/makefile
+++ b/makefile
@@ -103,7 +103,7 @@ clean-test:
 
 # Quick smoke test on generated small dataset (uses defaults)
 smoketest: main
-	uv run gen_testdata.py --rules 50 --packets 200 --seed 9 --out-dir Data
+	uv run scripts/gen_testdata.py --rules 50 --packets 200 --seed 9 --out-dir Data
 	./main -r Data/test_50 -p Data/test_50_trace --classifier hybrid --ht-loop 5 --ht-hash-inflation 8 --ht-seed 9 --metrics results.csv
 	@grep -q "ht_binth" results.csv && echo "smoketest ok" || (echo "smoketest missing header" && false)
 

--- a/makefile
+++ b/makefile
@@ -8,6 +8,27 @@ CXXFLAGS = -std=c++14 -pedantic -fpermissive -fopenmp -O3 \
            -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare
 LDFLAGS = -fopenmp
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+GXX15 := $(shell which g++-15 2>/dev/null)
+ifeq ($(GXX15),)
+LIBOMP_PREFIX := $(shell brew --prefix libomp)
+CXX = clang++
+CXXFLAGS = -std=c++14 -pedantic -fpermissive -O3 \
+           -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare \
+           -Xpreprocessor -fopenmp -I$(LIBOMP_PREFIX)/include
+LDFLAGS = -L$(LIBOMP_PREFIX)/lib -lomp
+else
+CXX = $(GXX15)
+CXXFLAGS = -std=c++14 -pedantic -fpermissive -fopenmp -O3 \
+           -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare
+LDFLAGS = -fopenmp
+endif
+NPROC = $(shell sysctl -n hw.ncpu)
+else
+NPROC = $(shell nproc)
+endif
+
 # Debug build with sanitizers
 ifdef DEBUG
 CXXFLAGS += -g -O0 -DDEBUG
@@ -66,13 +87,13 @@ clean:
 
 # --- GoogleTest test suite (CMake-based) ---
 test:
-	cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-	cmake --build build -j$$(nproc)
+	cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=$(CXX)
+	cmake --build build -j$(NPROC)
 	cd build && ctest --output-on-failure
 
 test-verbose:
-	cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-	cmake --build build -j$$(nproc)
+	cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=$(CXX)
+	cmake --build build -j$(NPROC)
 	cd build && ctest --output-on-failure --verbose
 
 clean-test:

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -3,10 +3,11 @@ import csv
 import sys
 from typing import Dict, List
 
+
 def parse_output_file(file_path: str) -> List[Dict[str, any]]:
     """
     Parse the output.txt file and extract metrics for each classification method.
-    
+
     Metrics extracted:
     - Dataset name (e.g., acl1_1k)
     - Construction time (ms)
@@ -16,112 +17,128 @@ def parse_output_file(file_path: str) -> List[Dict[str, any]]:
     - Total update time (s)
     - Average update time (us)
     - Throughput for update (Mpps)
-    
+
     Args:
         file_path: Path to the output.txt file
-        
+
     Returns:
         List of dictionaries containing all extracted metrics
     """
-    
+
     data = []
     current_dataset = None
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         content = f.read()
-    
+
     # Split by "-------------------------------" to separate different class runs
-    sections = content.split('-------------------------------')
-    
+    sections = content.split("-------------------------------")
+
     for section in sections:
-        lines = section.strip().split('\n')
-        
+        lines = section.strip().split("\n")
+
         # Check for dataset name (appears at the beginning of section)
         for line in lines:
             # Dataset names typically end with a number like acl1_1k, acl2_10k, etc.
-            if './' in line or '../' in line:
+            if "./" in line or "../" in line:
                 # Extract the dataset name from the path
-                dataset_match = re.search(r'([a-z]+\d+_\d+[a-z]*)', line)
+                dataset_match = re.search(r"([a-z]+\d+_\d+[a-z]*)", line)
                 if dataset_match:
                     current_dataset = dataset_match.group(1)
-        
+
         # Find the class name
         class_name = None
         for line in lines:
-            if 'class:' in line:
-                class_name = line.split('class:')[1].strip().split(':')[0]
+            if "class:" in line:
+                class_name = line.split("class:")[1].strip().split(":")[0]
                 break
-        
+
         if not class_name:
             continue
-        
+
         # Extract metrics
         metrics = {
-            'Dataset': current_dataset,
-            'Class': class_name,
-            'Construction_time_ms': None,
-            'Total_classification_time_s': None,
-            'Average_classification_time_us': None,
-            'Throughput_classification_Mpps': None,
-            'Total_update_time_s': None,
-            'Average_update_time_us': None,
-            'Throughput_update_Mpps': None,
+            "Dataset": current_dataset,
+            "Class": class_name,
+            "Construction_time_ms": None,
+            "Total_classification_time_s": None,
+            "Average_classification_time_us": None,
+            "Throughput_classification_Mpps": None,
+            "Total_update_time_s": None,
+            "Average_update_time_us": None,
+            "Throughput_update_Mpps": None,
         }
-        
-        section_text = '\n'.join(lines)
-        
+
+        section_text = "\n".join(lines)
+
         # Extract Construction time
-        construction_match = re.search(r'Construction time:\s*([\d.]+)\s*ms', section_text)
+        construction_match = re.search(
+            r"Construction time:\s*([\d.]+)\s*ms", section_text
+        )
         if construction_match:
-            metrics['Construction_time_ms'] = float(construction_match.group(1))
-        
+            metrics["Construction_time_ms"] = float(construction_match.group(1))
+
         # Extract Total classification time
-        total_class_match = re.search(r'Total classification time:\s*([\d.]+)\s*s', section_text)
+        total_class_match = re.search(
+            r"Total classification time:\s*([\d.]+)\s*s", section_text
+        )
         if total_class_match:
-            metrics['Total_classification_time_s'] = float(total_class_match.group(1))
-        
+            metrics["Total_classification_time_s"] = float(total_class_match.group(1))
+
         # Extract Average classification time
-        avg_class_match = re.search(r'Average classification time:\s*([\d.]+)\s*us', section_text)
+        avg_class_match = re.search(
+            r"Average classification time:\s*([\d.]+)\s*us", section_text
+        )
         if avg_class_match:
-            metrics['Average_classification_time_us'] = float(avg_class_match.group(1))
-        
+            metrics["Average_classification_time_us"] = float(avg_class_match.group(1))
+
         # Extract Throughput for classification
-        throughput_class_match = re.search(r'(?:Classify Performance:.*?)?Throughput:\s*([\d.]+)\s*Mpps(?=\n|Update)', section_text, re.DOTALL)
+        throughput_class_match = re.search(
+            r"(?:Classify Performance:.*?)?Throughput:\s*([\d.]+)\s*Mpps(?=\n|Update)",
+            section_text,
+            re.DOTALL,
+        )
         if throughput_class_match:
-            metrics['Throughput_classification_Mpps'] = float(throughput_class_match.group(1))
-        
+            metrics["Throughput_classification_Mpps"] = float(
+                throughput_class_match.group(1)
+            )
+
         # Extract Total update time
-        total_update_match = re.search(r'Total update time:\s*([\d.]+)\s*s', section_text)
+        total_update_match = re.search(
+            r"Total update time:\s*([\d.]+)\s*s", section_text
+        )
         if total_update_match:
-            metrics['Total_update_time_s'] = float(total_update_match.group(1))
-        
+            metrics["Total_update_time_s"] = float(total_update_match.group(1))
+
         # Extract Average update time
-        avg_update_match = re.search(r'Average update time:\s*([\d.]+)\s*us', section_text)
+        avg_update_match = re.search(
+            r"Average update time:\s*([\d.]+)\s*us", section_text
+        )
         if avg_update_match:
-            metrics['Average_update_time_us'] = float(avg_update_match.group(1))
-        
+            metrics["Average_update_time_us"] = float(avg_update_match.group(1))
+
         # Extract Throughput for update (second occurrence)
-        throughput_matches = re.findall(r'Throughput:\s*([\d.]+)\s*Mpps', section_text)
+        throughput_matches = re.findall(r"Throughput:\s*([\d.]+)\s*Mpps", section_text)
         if len(throughput_matches) >= 2:
-            metrics['Throughput_update_Mpps'] = float(throughput_matches[1])
-        
+            metrics["Throughput_update_Mpps"] = float(throughput_matches[1])
+
         data.append(metrics)
-    
+
     return data
 
 
-def save_to_csv(data: List[Dict], output_path: str = 'extracted_metrics.csv') -> None:
+def save_to_csv(data: List[Dict], output_path: str = "extracted_metrics.csv") -> None:
     """Save the extracted metrics to a CSV file."""
     if not data:
         print("No data to save")
         return
-    
+
     fieldnames = data[0].keys()
-    with open(output_path, 'w', newline='') as f:
+    with open(output_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(data)
-    
+
     print(f"Metrics saved to {output_path}")
 
 
@@ -130,58 +147,61 @@ def display_metrics(data: List[Dict]) -> None:
     if not data:
         print("No data to display")
         return
-    
+
     print("\n=== Extracted Metrics ===\n")
-    
+
     # Get column widths
     fieldnames = data[0].keys()
     col_widths = {field: len(field) for field in fieldnames}
-    
+
     for row in data:
         for field in fieldnames:
             value = str(row[field]) if row[field] is not None else "N/A"
             col_widths[field] = max(col_widths[field], len(value))
-    
+
     # Print header
     header = " | ".join(f"{field:<{col_widths[field]}}" for field in fieldnames)
     print(header)
     print("-" * len(header))
-    
+
     # Print rows
     for row in data:
-        row_str = " | ".join(f"{str(row[field] if row[field] is not None else 'N/A'):<{col_widths[field]}}" for field in fieldnames)
+        row_str = " | ".join(
+            f"{str(row[field] if row[field] is not None else 'N/A'):<{col_widths[field]}}"
+            for field in fieldnames
+        )
         print(row_str)
-    
+
     print(f"\nTotal records: {len(data)}")
 
 
 if __name__ == "__main__":
     # Default file names
-    input_file = 'output.txt'
-    output_file = 'extracted_metrics.csv'
-    
+    input_file = "output.txt"
+    output_file = "extracted_metrics.csv"
+
     # Parse command-line arguments
     if len(sys.argv) > 1:
         input_file = sys.argv[1]
     if len(sys.argv) > 2:
         output_file = sys.argv[2]
-    
+
     # Validate input file exists
     try:
-        with open(input_file, 'r') as f:
+        with open(input_file, "r") as f:
             pass
     except FileNotFoundError:
         print(f"Error: Input file '{input_file}' not found")
         sys.exit(1)
-    
+
     print(f"Processing: {input_file}")
     print(f"Output: {output_file}\n")
-    
+
     # Parse the output file
     data = parse_output_file(input_file)
-    
+
     # Display the metrics
     display_metrics(data)
-    
+
     # Save to CSV
     save_to_csv(data, output_file)

--- a/scripts/gen_testdata.py
+++ b/scripts/gen_testdata.py
@@ -4,7 +4,9 @@ Generate ClassBench-format rule files and matching packet trace files
 for testing HybridTSS.
 
 Usage:
-    python3 gen_testdata.py [--rules N] [--packets M] [--out-dir DIR] [--seed S]
+    uv run scripts/gen_testdata.py [--rules N] [--packets M] [--out-dir DIR] [--seed S]
+    # fallback:
+    python3 scripts/gen_testdata.py [--rules N] [--packets M] [--out-dir DIR] [--seed S]
 
 Outputs:
     <out-dir>/test_<N>        - rule file

--- a/tests/hybrid_tss_test.cpp
+++ b/tests/hybrid_tss_test.cpp
@@ -4,14 +4,34 @@
 #include <gtest/gtest.h>
 #include "ElementaryClasses.h"
 #include "HybridTSS/HybridTSS.h"
+#include <atomic>
 #include <cstdio>
 #include <chrono>
+#include <cstdint>
 #include <string>
+#include <unistd.h>
+#include <utility>
 
 static std::string MakeTempQTablePath() {
-    auto now = std::chrono::steady_clock::now().time_since_epoch().count();
-    return "Data/test_qtable_" + std::to_string(now) + ".bin";
+    static std::atomic<uint64_t> counter{0};
+    const auto now = static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+    const uint64_t seq = counter.fetch_add(1, std::memory_order_relaxed);
+    return "Data/test_qtable_" + std::to_string(getpid()) + "_" + std::to_string(now) + "_" + std::to_string(seq) + ".bin";
 }
+
+class TempFileGuard {
+public:
+    explicit TempFileGuard(std::string path) : path_(std::move(path)) {}
+    ~TempFileGuard() {
+        if (!path_.empty()) {
+            remove(path_.c_str());
+        }
+    }
+    const std::string& path() const { return path_; }
+
+private:
+    std::string path_;
+};
 
 class HybridTSSTest : public ::testing::Test {
 protected:
@@ -104,7 +124,8 @@ TEST_F(HybridTSSTest, InferenceOnlyWithoutModelFails) {
 }
 
 TEST_F(HybridTSSTest, TrainAndSaveThenLoadInferenceWorks) {
-    const std::string qtable_path = MakeTempQTablePath();
+    TempFileGuard qtable_guard(MakeTempQTablePath());
+    const std::string& qtable_path = qtable_guard.path();
 
     HybridOptions train_opts;
     train_opts.train_online = true;
@@ -143,5 +164,4 @@ TEST_F(HybridTSSTest, TrainAndSaveThenLoadInferenceWorks) {
     }
     EXPECT_EQ(misclassified, 0);
 
-    remove(qtable_path.c_str());
 }

--- a/tests/hybrid_tss_test.cpp
+++ b/tests/hybrid_tss_test.cpp
@@ -5,6 +5,13 @@
 #include "ElementaryClasses.h"
 #include "HybridTSS/HybridTSS.h"
 #include <cstdio>
+#include <chrono>
+#include <string>
+
+static std::string MakeTempQTablePath() {
+    auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    return "Data/test_qtable_" + std::to_string(now) + ".bin";
+}
 
 class HybridTSSTest : public ::testing::Test {
 protected:
@@ -82,4 +89,59 @@ TEST_F(HybridTSSTest, DeleteRuleDoesNotCrash) {
     for (int i = 0; i < 10 && i < NRules(); i++) {
         ASSERT_NO_FATAL_FAILURE(PC()->DeleteRule(rules[i]));
     }
+}
+
+TEST_F(HybridTSSTest, InferenceOnlyWithoutModelFails) {
+    HybridOptions opts;
+    opts.train_online = false;
+    HybridTSS infer_only(opts);
+
+    std::string err;
+    EXPECT_FALSE(infer_only.ConstructClassifierSafe(rules, &err));
+    EXPECT_FALSE(infer_only.IsReady());
+    EXPECT_FALSE(err.empty());
+    EXPECT_FALSE(infer_only.LastError().empty());
+}
+
+TEST_F(HybridTSSTest, TrainAndSaveThenLoadInferenceWorks) {
+    const std::string qtable_path = MakeTempQTablePath();
+
+    HybridOptions train_opts;
+    train_opts.train_online = true;
+    train_opts.qtable_out_path = qtable_path;
+    train_opts.seed = 7;
+    HybridTSS trainer(train_opts);
+
+    std::string train_err;
+    ASSERT_TRUE(trainer.ConstructClassifierSafe(rules, &train_err)) << train_err;
+
+    FILE* f = fopen(qtable_path.c_str(), "rb");
+    ASSERT_NE(f, nullptr) << "QTable file was not created";
+    fclose(f);
+
+    HybridOptions infer_opts;
+    infer_opts.train_online = false;
+    infer_opts.qtable_in_path = qtable_path;
+    HybridTSS infer(infer_opts);
+
+    std::string infer_err;
+    ASSERT_TRUE(infer.ConstructClassifierSafe(rules, &infer_err)) << infer_err;
+    ASSERT_TRUE(infer.IsReady());
+
+    int nRules = NRules();
+    int misclassified = 0;
+    for (const auto& pkt : packets) {
+        int matchPri = infer.ClassifyAPacket(pkt);
+        int result = nRules - 1 - matchPri;
+        int expected = static_cast<int>(pkt[5]);
+        if (result == nRules && expected == nRules) {
+            continue;
+        }
+        if (result == nRules || expected < result) {
+            misclassified++;
+        }
+    }
+    EXPECT_EQ(misclassified, 0);
+
+    remove(qtable_path.c_str());
 }


### PR DESCRIPTION
## Summary
- split HybridTSS construction into safe train-or-load and build phases, adding inference-only mode with fail-fast behavior when no QTable is provided
- add QTable artifact persistence/loading APIs (`HTQ1` header), CLI flags (`--ht-train-online`, `--ht-qtable-in`, `--ht-qtable-out`), and coverage for train-save-load plus inference-only failure paths
- move helper Python tools into `scripts/`, update GitHub Actions to use `uv run scripts/gen_testdata.py`, and refresh run/docs references

## Validation
- `make clean && make -j4`
- `make clean-test && make test`
- `uv run scripts/gen_testdata.py --rules 10 --packets 20 --seed 7 --out-dir Data`
- `./main -r Data/test_100 -p Data/test_100_trace --classifier hybrid --ht-loop 2 --ht-seed 9 --trials 1 --skip-updates --ht-qtable-out Data/test_hybrid.qtable`
- `./main -r Data/test_100 -p Data/test_100_trace --classifier hybrid --ht-train-online 0 --ht-qtable-in Data/test_hybrid.qtable --trials 1 --skip-updates`