### PR TITLE
Add debug loss curve export and no-match logging guard

### DIFF
--- a/HybridTSS/HybridTSS.cpp
+++ b/HybridTSS/HybridTSS.cpp
@@ -612,6 +612,7 @@ void HybridTSS::train(const vector<Rule> &rules) {
 
 #ifdef DEBUG
     vector<double> rewardCurve(loopNum, 0.0);
+    vector<double> lossCurve(loopNum, 0.0);
 #endif
 
     QTable.assign(stateSize, vector<double>(actionSize, 0.0));
@@ -681,6 +682,8 @@ void HybridTSS::train(const vector<Rule> &rules) {
 
 #ifdef DEBUG
             double episodeReward = 0.0;
+            double episodeSqErr = 0.0;
+            int episodeUpdates = 0;
 #endif
 
             // thread-local Q-table 更新
@@ -696,14 +699,23 @@ void HybridTSS::train(const vector<Rule> &rules) {
                 count++;
 
                 auto it = Qlocal.find(k);
+#ifdef DEBUG
+                double q_old = 0.0;
+#endif
                 if (it == Qlocal.end()) {
                     Qlocal[k] = val;
                 } else {
+#ifdef DEBUG
+                    q_old = it->second;
+#endif
                     it->second += alpha * (val - it->second);
                 }
 
 #ifdef DEBUG
+                const double delta = val - q_old;
                 episodeReward += val;
+                episodeSqErr += delta * delta;
+                episodeUpdates++;
 #endif
             }
 
@@ -712,6 +724,10 @@ void HybridTSS::train(const vector<Rule> &rules) {
                 rewardCurve[i] = episodeReward;
             else
                 rewardCurve[i] = rewardCurve[i-1] + (episodeReward - rewardCurve[i-1]) / (i+1);
+
+            lossCurve[i] = (episodeUpdates > 0)
+                ? (episodeSqErr / static_cast<double>(episodeUpdates))
+                : 0.0;
 #endif
         }
     }
@@ -754,8 +770,9 @@ void HybridTSS::train(const vector<Rule> &rules) {
 
     cout << "Saving learning curve to learning_curve.csv ..." << endl;
     ofstream fout("learning_curve.csv");
+    fout << "episode,reward,loss\n";
     for (int i = 0; i < loopNum; i++) {
-        fout << i << "," << rewardCurve[i] << "\n";
+        fout << i << "," << rewardCurve[i] << "," << lossCurve[i] << "\n";
     }
     fout.close();
     cout << "Learning curve export finished" << endl;

--- a/HybridTSS/HybridTSS.cpp
+++ b/HybridTSS/HybridTSS.cpp
@@ -611,7 +611,7 @@ void HybridTSS::train(const vector<Rule> &rules) {
     const double epsilonDecay = options.epsilon_decay;
 
 #ifdef DEBUG
-    vector<double> rewardCurve(loopNum, 0.0);
+    vector<double> episodeRewardRaw(loopNum, 0.0);
     vector<double> lossCurve(loopNum, 0.0);
 #endif
 
@@ -704,26 +704,25 @@ void HybridTSS::train(const vector<Rule> &rules) {
 #endif
                 if (it == Qlocal.end()) {
                     Qlocal[k] = val;
+#ifdef DEBUG
+                    episodeReward += val;
+#endif
                 } else {
 #ifdef DEBUG
                     q_old = it->second;
 #endif
                     it->second += alpha * (val - it->second);
-                }
-
 #ifdef DEBUG
-                const double delta = val - q_old;
-                episodeReward += val;
-                episodeSqErr += delta * delta;
-                episodeUpdates++;
+                    const double delta = val - q_old;
+                    episodeReward += val;
+                    episodeSqErr += delta * delta;
+                    episodeUpdates++;
 #endif
+                }
             }
 
 #ifdef DEBUG
-            if (i == 0)
-                rewardCurve[i] = episodeReward;
-            else
-                rewardCurve[i] = rewardCurve[i-1] + (episodeReward - rewardCurve[i-1]) / (i+1);
+            episodeRewardRaw[i] = episodeReward;
 
             lossCurve[i] = (episodeUpdates > 0)
                 ? (episodeSqErr / static_cast<double>(episodeUpdates))
@@ -768,8 +767,19 @@ void HybridTSS::train(const vector<Rule> &rules) {
     cout << "[DEBUG] Contention Ratio: "
          << (double)lockContended / lockAttempts * 100.0 << "%" << endl;
 
+    vector<double> rewardCurve(loopNum, 0.0);
+    double runningAvg = 0.0;
+    for (int i = 0; i < loopNum; ++i) {
+        runningAvg += (episodeRewardRaw[i] - runningAvg) / static_cast<double>(i + 1);
+        rewardCurve[i] = runningAvg;
+    }
+
     cout << "Saving learning curve to learning_curve.csv ..." << endl;
     ofstream fout("learning_curve.csv");
+    if (!fout.is_open()) {
+        cerr << "Failed to open learning_curve.csv for writing" << endl;
+        return;
+    }
     fout << "episode,reward,loss\n";
     for (int i = 0; i < loopNum; i++) {
         fout << i << "," << rewardCurve[i] << "," << lossCurve[i] << "\n";

--- a/RUN.md
+++ b/RUN.md
@@ -57,3 +57,11 @@ If `--ht-train-online 0` is used without `--ht-qtable-in`, the run fails fast wi
 ```bash
 uvx cpp-linter --style file --lines-changed-only true --file-annotations false --tidy-checks="*"
 ```
+
+## Debug Training Curve
+
+When built with `make DEBUG=1`, HybridTSS training exports `learning_curve.csv` with:
+
+- `episode`
+- `reward` (running average episode reward)
+- `loss` (mean squared TD error per episode)

--- a/main.cpp
+++ b/main.cpp
@@ -64,9 +64,14 @@ bool testPerformance(PacketClassifier *p, const Options& opts, const vector<int>
         End = std::chrono::steady_clock::now();
         sumTime += End - Start;
         for (int j = 0; j < nPacket; j++) {
-            if (results[j] == nRules || packets[j][5] < results[j]) {
-                cout << rules[packets[j][5]].priority << "\t" << results[j] << "\t" << packets[j][5] << endl;
-            matchMiss++;
+            const int expected = static_cast<int>(packets[j][5]);
+            if (results[j] == nRules || expected < results[j]) {
+                if (expected >= 0 && expected < nRules) {
+                    cout << rules[expected].priority << "\t" << results[j] << "\t" << expected << endl;
+                } else {
+                    cout << "no_match\t" << results[j] << "\t" << expected << endl;
+                }
+                matchMiss++;
             }
         }
     }


### PR DESCRIPTION
## Summary
- add DEBUG-only training loss tracking in HybridTSS and export `learning_curve.csv` with `episode,reward,loss` columns
- document the new debug curve output in `RUN.md` so reward/loss analysis workflow is explicit
- fix debug mismatch logging in `main.cpp` to handle no-match sentinel safely and avoid out-of-bounds rule indexing

## Validation
- `make -j4`
- `make clean-test && make test`
- `make DEBUG=1 -j4`
- `./main -r Data/test_100 -p Data/test_100_trace --classifier hybrid --ht-loop 3 --ht-seed 9 --skip-updates`