### PR TITLE
docs(hybridtss): freeze HTQ1 model artifact contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ cd build && ctest --output-on-failure
 ./main -r ./Data/acl1_1k -p ./Data/acl1_1k_trace --classifier hybrid --ht-loop 40 --ht-hash-inflation 8 --ht-seed 123
 ```
 
+### Model Artifact Contract
+
+- HybridTSS uses a versioned binary model artifact (`.qtable`) for train/use
+  separation.
+- Contract details (layout, compatibility, and failure reasons) are documented
+  in `docs/htq1-model-contract.md`.
+
 ## Input Formats
 
 ### Rule file (ClassBench format)

--- a/RUN.md
+++ b/RUN.md
@@ -52,6 +52,9 @@ uv run scripts/gen_testdata.py --rules 1000 --packets 10000 --seed 42 --out-dir 
 
 If `--ht-train-online 0` is used without `--ht-qtable-in`, the run fails fast with an explicit error.
 
+For the frozen `HTQ1` binary contract (header/payload layout, compatibility,
+and loader failure reasons), see `docs/htq1-model-contract.md`.
+
 ## Lint
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -53,6 +53,36 @@
 
 ## Planned / Next
 
+### Research Track (PR-based, OVS + OpenFlow first)
+- [x] PR1: Freeze model artifact contract (HTQ1)
+  - Scope: document `.qtable` header/payload layout, compatibility rules, and load failure reasons
+  - Acceptance: same artifact loads reproducibly across machines; mismatch errors are explicit
+- [ ] PR2: Add OVS userspace backend shim (feature-flagged)
+  - Scope: dpcls backend skeleton for `build/lookup/insert/delete`; clean init/teardown path
+  - Acceptance: backend can be enabled/disabled safely; disabled path matches native behavior
+- [ ] PR3: Implement rule translation + fallback policy
+  - Scope: support IPv4 5-tuple + proto mask (0/0xFF); unsupported matches fallback to native dpcls
+  - Acceptance: OpenFlow rules classify correctly; fallback counter increments on unsupported rules
+- [ ] PR4: Add end-to-end research harness (parity + perf)
+  - Scope: fixed-seed dataset/flows, HybridTSS vs native dpcls correctness parity, throughput/p99 scripts
+  - Acceptance: reproducible report with correctness and performance numbers
+- [ ] PR5: Add reload/rollback lite (optional, recommended)
+  - Scope: build new instance then swap; keep old instance on failure; basic rollback command
+  - Acceptance: reload does not break forwarding; failed reload keeps previous model active
+- [ ] PR6: Add minimal observability (optional)
+  - Scope: `show-model`, `active_model_id`, `fallback_count`, `reload_success/fail`
+  - Acceptance: enough runtime visibility for debugging without hot-path logging
+
+### Milestones (research scope)
+- [ ] M1 (Week 1): PR1 + PR2 complete; userspace OVS backend compiles and can be toggled
+- [ ] M2 (Week 2): PR3 + PR4 complete; OpenFlow functional test + parity/perf results available
+- [ ] M3 (Week 3, optional): PR5 (+PR6 if time); basic safe reload and minimal runtime visibility
+
+### Out of Scope for research MVP
+- [ ] Kernel datapath integration
+- [ ] Full production-grade observability/counters per PMD
+- [ ] Broad match-field support beyond the defined IPv4 5-tuple subset
+
 ### OVS Integration (dpcls backend)
 - [ ] Define dpcls backend shim: miniflow/minimask → `Rule`/`Packet`, build/lookup/insert/delete/stats API
 - [ ] Decide update model: RCU swap (new instance build + pointer flip) and/or per-PMD instances; keep EMC behavior unchanged

--- a/docs/htq1-model-contract.md
+++ b/docs/htq1-model-contract.md
@@ -5,7 +5,8 @@ training and inference can evolve independently.
 
 ## Scope
 
-- Artifact file extension: `.qtable` (binary)
+- Recommended artifact file extension: `.qtable` (binary; extension is
+  conventional only and not enforced by the runtime loader)
 - Producer: HybridTSS training path (`train_online=true` + `qtable_out_path`)
 - Consumer: HybridTSS inference path (`train_online=false` + `qtable_in_path`)
 - Current writer/reader implementation: `HybridTSS/HybridTSS.cpp`
@@ -50,7 +51,12 @@ Implication:
 
 ## Failure Reasons (Current Runtime Messages)
 
-The loader/writer reports explicit reasons through `LastError()` / output `err`:
+The loader (`LoadQTable()` / `ConstructClassifierSafe()`) reports reasons via
+`LastError()` and optional output `err`. The writer (`SaveQTable()`) reports
+reasons via output `err` only (it does not update `LastError()` directly unless
+the caller propagates the message).
+
+Current messages:
 
 - save path:
   - `QTable is empty; nothing to save`
@@ -66,7 +72,8 @@ The loader/writer reports explicit reasons through `LastError()` / output `err`:
   - `QTable dimensions mismatch with state/action bits`
   - `QTable payload truncated: <path>`
 - precondition path:
-  - `inference-only mode requires --ht-qtable-in`
+  - runtime API (`HybridTSS`): `inference-only mode requires --ht-qtable-in`
+  - CLI validator (`./main`): `--ht-train-online 0 requires --ht-qtable-in <path>`
   - `ht-state-bits must be in [1, 30]`
   - `ht-action-bits must be in [1, 30]`
 

--- a/docs/htq1-model-contract.md
+++ b/docs/htq1-model-contract.md
@@ -1,0 +1,104 @@
+# HTQ1 Model Artifact Contract
+
+This document freezes the v1 HybridTSS model artifact contract (`HTQ1`) so
+training and inference can evolve independently.
+
+## Scope
+
+- Artifact file extension: `.qtable` (binary)
+- Producer: HybridTSS training path (`train_online=true` + `qtable_out_path`)
+- Consumer: HybridTSS inference path (`train_online=false` + `qtable_in_path`)
+- Current writer/reader implementation: `HybridTSS/HybridTSS.cpp`
+
+## Binary Format (HTQ1)
+
+All integer fields are little-endian `uint32_t`.
+
+Header:
+
+1. `magic[4]` = ASCII `HTQ1`
+2. `version` = `1`
+3. `state_bits`
+4. `action_bits`
+5. `rows`
+6. `cols`
+
+Payload:
+
+- `rows * cols` values, row-major, each value is IEEE-754 `double` (8 bytes)
+
+Canonical sizes:
+
+- `rows == (1 << state_bits)`
+- `cols == (1 << action_bits)`
+
+## Compatibility Rules
+
+Load is accepted only if all checks pass:
+
+1. File is readable and header is complete
+2. `magic == HTQ1`
+3. `version == 1`
+4. `state_bits` and `action_bits` exactly match current `HybridOptions`
+5. `rows`/`cols` match the bit-derived dimensions
+6. Payload length is sufficient for all doubles
+
+Implication:
+
+- A model trained with one `(state_bits, action_bits)` pair is not loadable into
+  runtime configured with a different pair.
+
+## Failure Reasons (Current Runtime Messages)
+
+The loader/writer reports explicit reasons through `LastError()` / output `err`:
+
+- save path:
+  - `QTable is empty; nothing to save`
+  - `QTable rows have inconsistent sizes`
+  - `failed to open QTable output file: <path>`
+  - `failed while writing QTable file: <path>`
+- load path:
+  - `failed to open QTable input file: <path>`
+  - `invalid QTable header: <path>`
+  - `QTable magic mismatch: <path>`
+  - `QTable version mismatch`
+  - `QTable bits mismatch with current HybridOptions`
+  - `QTable dimensions mismatch with state/action bits`
+  - `QTable payload truncated: <path>`
+- precondition path:
+  - `inference-only mode requires --ht-qtable-in`
+  - `ht-state-bits must be in [1, 30]`
+  - `ht-action-bits must be in [1, 30]`
+
+## Train / Use Separation Workflow
+
+Train and export once:
+
+```bash
+./main -r ./Data/acl1_1k -p ./Data/acl1_1k_trace \
+  --classifier hybrid \
+  --ht-train-online 1 \
+  --ht-qtable-out ./Data/hybrid_acl1_1k.qtable
+```
+
+Inference only:
+
+```bash
+./main -r ./Data/acl1_1k -p ./Data/acl1_1k_trace \
+  --classifier hybrid \
+  --ht-train-online 0 \
+  --ht-qtable-in ./Data/hybrid_acl1_1k.qtable
+```
+
+## Reproducibility Notes
+
+- Use a fixed `--ht-seed` during training for deterministic runs.
+- Keep `(state_bits, action_bits)` identical between training and inference.
+- Keep the same architecture assumptions for binary portability
+  (little-endian + IEEE-754 double).
+
+## Versioning Policy
+
+- `HTQ1` is frozen as v1 contract.
+- Future format changes must use a new magic/version contract (for example
+  `HTQ2`) while preserving backward read support where practical.


### PR DESCRIPTION
## Summary
- Add `docs/htq1-model-contract.md` to freeze the HTQ1 `.qtable` binary artifact contract for train/use separation.
- Document binary layout, compatibility checks, and current load/save failure reasons used by `HybridTSS`.
- Link the contract doc from `README.md` and `RUN.md`, and capture the roadmap step in `TODO.md`.