### PR TITLE
fix(main): ignore correct no-match results in metrics

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -65,6 +65,9 @@ bool testPerformance(PacketClassifier *p, const Options& opts, const vector<int>
         sumTime += End - Start;
         for (int j = 0; j < nPacket; j++) {
             const int expected = static_cast<int>(packets[j][5]);
+            if (results[j] == nRules && expected == nRules) {
+                continue;
+            }
             if (results[j] == nRules || expected < results[j]) {
                 if (expected >= 0 && expected < nRules) {
                     cout << rules[expected].priority << "\t" << results[j] << "\t" << expected << endl;


### PR DESCRIPTION
## Summary
- Treat `result == nRules && expected == nRules` as a correct no-match in benchmark accounting
- Prevent no-match packets from inflating the `misclassified` metric

## Verification
- `make main`
- `./main -r Data/test_100 -p Data/test_100_trace --classifier pstss,cuttss,hybrid --trials 1 --skip-updates --ht-loop 2 --ht-seed 9 --metrics /private/tmp/hybridtss_issue11_smoke.csv`

Closes #11