### PR TITLE
fix(hybridtss): preserve hash insert child context

### DIFF
--- a/HybridTSS/SubHybridTSS.cpp
+++ b/HybridTSS/SubHybridTSS.cpp
@@ -115,12 +115,12 @@ vector<SubHybridTSS *> SubHybridTSS::ConstructClassifier(const vector<int> &op, 
             }
             for (int i = 0; i < nHashTable + 1; i++) {
                 if (!subRules[i].empty()) {
-                    children[i] = new SubHybridTSS(subRules[i], hashChildenState, this);
+                    children[i] = new SubHybridTSS(subRules[i], hashChildenState, this, inflation_param);
                     children[i]->bigOffset = this->bigOffset;
                 }
             }
             if (!bigRules.empty()) {
-                this->bigClassifier = new SubHybridTSS(bigRules, hashBigState, this);
+                this->bigClassifier = new SubHybridTSS(bigRules, hashBigState, this, inflation_param);
                 this->bigClassifier->bigOffset = this->bigOffset;
                 this->bigClassifier->bigOffset[dim] = bit;
             }
@@ -255,7 +255,11 @@ void SubHybridTSS::InsertRule(const Rule &rule) {
                 if (children[Key]) {
                     children[Key]->InsertRule(rule);
                 } else {
-                    children[Key] = new SubHybridTSS({rule});
+                    int hashChildenState = state;
+                    hashChildenState |= (1 << (5 * dim));
+                    hashChildenState |= ((bit - (dim == 0 || dim == 1 ? 12 : 9)) << (5 * dim + 1));
+                    children[Key] = new SubHybridTSS({rule}, hashChildenState, this, inflation_param);
+                    children[Key]->bigOffset = this->bigOffset;
                     children[Key]->ConstructClassifier({linear, -1, -1}, "build");
                 }
             }

--- a/tests/hybrid_tss_test.cpp
+++ b/tests/hybrid_tss_test.cpp
@@ -156,6 +156,27 @@ TEST(SubHybridTSSLinearDeleteTest, DuplicatePriorityDeletesOnlyMatchingId) {
     EXPECT_EQ(node.ClassifyAPacket(MakePacket(3)), 3);
 }
 
+TEST(SubHybridTSSHashInsertTest, EmptyBucketInsertPreservesChildContext) {
+    Rule initial = MakeExactRule(10, 1, 0x01000000);
+    Rule inserted = MakeExactRule(20, 2, 0x00100000);
+    SubHybridTSS node({initial}, 3);
+    node.ConstructClassifier({Hash, FieldSA, 0}, "build");
+
+    node.InsertRule(inserted);
+
+    EXPECT_EQ(node.ClassifyAPacket(MakePacket(initial.range[FieldSA][LowDim])), 10);
+    EXPECT_EQ(node.ClassifyAPacket(MakePacket(inserted.range[FieldSA][LowDim])), 20);
+
+    int hashChildStateCount = 0;
+    for (const auto& reward : node.getReward()) {
+        ASSERT_FALSE(reward.empty());
+        if (reward[0] == 1) {
+            hashChildStateCount++;
+        }
+    }
+    EXPECT_EQ(hashChildStateCount, 2);
+}
+
 TEST_F(HybridTSSTest, InferenceOnlyWithoutModelFails) {
     HybridOptions opts;
     opts.train_online = false;


### PR DESCRIPTION
## Summary
- Preserve parent/state/bigOffset/inflation context for hash children created during runtime insert
- Pass hash inflation explicitly during build-time hash child creation
- Add a regression test for inserting into an empty hash bucket

## Tests
- ctest --test-dir build --output-on-failure

Fixes #18