### PR TITLE
fix(cuttss): harden table counting and query overload

### DIFF
--- a/CutTSS/CutTSS.cpp
+++ b/CutTSS/CutTSS.cpp
@@ -105,8 +105,8 @@ int CutTSS::ClassifyAPacket(const Packet& packet, uint64_t& Query) {
     if (nodeSet[2] && maxPri[2] > matchPri)
         matchPri = max(matchPri, trieLookup(packet, nodeSet[2], 2, Query));
     if (PSbig && maxPri[3] > matchPri) {
-        if (nodeSet[3]->classifier.size() < rtssleaf * PSbig->NumTables()) {
-            for (const Rule& rule : nodeSet[3]->classifier) {
+        if (subset.back().size() <= rtssleaf * PSbig->NumTables()) {
+            for (const Rule& rule : subset.back()) {
                 Query++;
                 if (rule.MatchesPacket(packet)) {
                     matchPri = max(matchPri, rule.priority);
@@ -528,11 +528,14 @@ void CutTSS::trieInsert(const Rule& insert_rule, CutTSSNode* root, int speedUpFl
 }
 
 size_t CutTSS::NumTables() const {
-    int totTables = 0;
-    for (int i = 0; i < subset.size(); i++) {
-        if (!subset.empty()) {
+    size_t totTables = 0;
+    for (const auto* node : nodeSet) {
+        if (node) {
             totTables++;
         }
+    }
+    if (PSbig) {
+        totTables++;
     }
     return totTables;
 }

--- a/tests/cut_tss_test.cpp
+++ b/tests/cut_tss_test.cpp
@@ -5,6 +5,23 @@
 #include "CutTSS/CutTSS.h"
 #include <cstdio>
 
+static Rule MakeCutTSSRule(int priority, int id, unsigned src_prefix, unsigned dst_prefix, Point src_ip, Point dst_ip) {
+    Rule r;
+    r.priority = priority;
+    r.id = id;
+    r.prefix_length = {src_prefix, dst_prefix, 0, 0, 0};
+    r.range[FieldSA] = {{src_ip, src_ip}};
+    r.range[FieldDA] = {{dst_ip, dst_ip}};
+    r.range[FieldSP] = {{0, 65535}};
+    r.range[FieldDP] = {{0, 65535}};
+    r.range[FieldProto] = {{0, 255}};
+    return r;
+}
+
+static Packet MakeCutTSSPacket(Point src_ip, Point dst_ip) {
+    return {src_ip, dst_ip, 0, 0, 0};
+}
+
 class CutTSSTest : public ::testing::Test {
 protected:
     void SetUp() override {
@@ -75,4 +92,23 @@ TEST_F(CutTSSTest, DeleteRuleDoesNotCrash) {
     for (int i = 0; i < 10 && i < static_cast<int>(rules.size()); i++) {
         ASSERT_NO_FATAL_FAILURE(classifier->DeleteRule(rules[i]));
     }
+}
+
+TEST(CutTSSRegressionTest, QueryOverloadClassifiesPSbigRule) {
+    CutTSS classifier;
+    Rule big = MakeCutTSSRule(10, 1, 0, 0, 0x01000000, 0x02000000);
+    classifier.ConstructClassifier({big});
+
+    uint64_t query = 0;
+    EXPECT_EQ(classifier.ClassifyAPacket(MakeCutTSSPacket(0x01000000, 0x02000000), query), 10);
+    EXPECT_GT(query, 0u);
+}
+
+TEST(CutTSSRegressionTest, NumTablesCountsOnlyPopulatedSubsets) {
+    CutTSS classifier;
+    Rule sourceOnly = MakeCutTSSRule(20, 1, 32, 0, 0x01000000, 0x02000000);
+    Rule big = MakeCutTSSRule(10, 2, 0, 0, 0x03000000, 0x04000000);
+    classifier.ConstructClassifier({sourceOnly, big});
+
+    EXPECT_EQ(classifier.NumTables(), 2u);
 }


### PR DESCRIPTION
## Summary
- Fix CutTSS query-count overload so PSbig uses subset.back() instead of out-of-bounds nodeSet[3]
- Fix CutTSS NumTables() to count only populated nodeSet entries plus PSbig
- Add regression tests for PSbig overload classification and mixed populated table counts

## Tests
- ctest --test-dir build --output-on-failure

Fixes #10
Fixes #12