### PR TITLE
fix(hybridtss): make training deterministic

### DIFF
--- a/HybridTSS/HybridTSS.cpp
+++ b/HybridTSS/HybridTSS.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <algorithm>
 #include <cstring>
+#include <random>
 #include <stdexcept>
 
 using namespace std;
@@ -428,6 +429,11 @@ bool HybridTSS::LoadQTable(const string& path, string* err) {
 // To-do: 方法冗余待优化，编码方式待修改，目的支持单个维度多次选取
 // -----------------------------------------------------------------------------
 vector<int> HybridTSS::getAction(SubHybridTSS *state, int epsilion) {
+    std::mt19937 gen(0);
+    return getAction(state, epsilion, gen);
+}
+
+vector<int> HybridTSS::getAction(SubHybridTSS *state, int epsilion, std::mt19937& gen) {
     if (!state) {
         cout << "state node exist" << endl;
         exit(-1);
@@ -448,7 +454,6 @@ vector<int> HybridTSS::getAction(SubHybridTSS *state, int epsilion) {
     if (static_cast<double>(nodeRules.size()) <= rtssleaf * static_cast<double>(tupleKey.size())) {
         return {TM, -1, -1};
     }
-    int num = rand() % 100;
     if (epsilion == 100) {
         // baseline
         if ((s & 1) == 0) {
@@ -487,6 +492,8 @@ vector<int> HybridTSS::getAction(SubHybridTSS *state, int epsilion) {
     if (rews.empty()) {
         return {TM, -1, -1};
     }
+    std::uniform_int_distribution<int> percentDist(0, 99);
+    int num = percentDist(gen);
     if (num <= epsilion) {
         // E-greedy
         vector<int> op;
@@ -501,7 +508,8 @@ vector<int> HybridTSS::getAction(SubHybridTSS *state, int epsilion) {
         return op;
     } else {
         // random explore
-        int N = rand() % rews.size();
+        std::uniform_int_distribution<size_t> actionDist(0, rews.size() - 1);
+        size_t N = actionDist(gen);
         return Actions[N];
     }
 
@@ -626,13 +634,6 @@ void HybridTSS::train(const vector<Rule> &rules) {
     atomic<int> progressCounter(0);
     atomic<int> nextPrint(progressStep);
 
-#ifdef DEBUG
-    std::atomic<long long> lockAttempts{0};
-    std::atomic<long long> lockContended{0};
-    omp_lock_t qLock;
-    omp_init_lock(&qLock);
-#endif
-
     #pragma omp parallel
     {
         int tid = omp_get_thread_num();
@@ -672,7 +673,7 @@ void HybridTSS::train(const vector<Rule> &rules) {
 
             while (!que.empty()) {
                 SubHybridTSS *node = que.front(); que.pop();
-                vector<int> op = getAction(node, epsilon * 100.0);
+                vector<int> op = getAction(node, epsilon * 100.0, gen);
                 for (auto *child : node->ConstructClassifier(op, "train")) {
                     if (child) que.push(child);
                 }
@@ -735,38 +736,18 @@ void HybridTSS::train(const vector<Rule> &rules) {
 
     vector<vector<int>> QCount(stateSize, vector<int>(actionSize, 0));
 
-    #pragma omp parallel for schedule(static)
     for (int t = 0; t < numThreads; ++t) {
         for (const auto& kv : localQ[t]) {
             int s = key_state(kv.first);
             int a = key_action(kv.first);
             int c = localCount[t][kv.first];
 
-#ifdef DEBUG
-            lockAttempts++;
-            if (!omp_test_lock(&qLock)) {
-                lockContended++;
-                omp_set_lock(&qLock);
-            }
-#endif
-            #pragma omp critical
-            {
-                QTable[s][a] = (QTable[s][a] * QCount[s][a] + kv.second * c) / (QCount[s][a] + c);
-                QCount[s][a] += c;
-            }
-#ifdef DEBUG
-            omp_unset_lock(&qLock);
-#endif
+            QTable[s][a] = (QTable[s][a] * QCount[s][a] + kv.second * c) / (QCount[s][a] + c);
+            QCount[s][a] += c;
         }
     }
 
 #ifdef DEBUG
-    omp_destroy_lock(&qLock);
-    cout << "[DEBUG] Lock Attempts: " << lockAttempts << endl;
-    cout << "[DEBUG] Lock Contended: " << lockContended << endl;
-    cout << "[DEBUG] Contention Ratio: "
-         << (double)lockContended / lockAttempts * 100.0 << "%" << endl;
-
     vector<double> rewardCurve(loopNum, 0.0);
     double runningAvg = 0.0;
     for (int i = 0; i < loopNum; ++i) {

--- a/HybridTSS/HybridTSS.h
+++ b/HybridTSS/HybridTSS.h
@@ -2,6 +2,7 @@
 #define HYBRIDTSSV1_2_HYBRIDTSS_H
 #include "SubHybridTSS.h"
 #include <cstdint>
+#include <random>
 #include <string>
 
 struct HybridOptions {
@@ -59,6 +60,7 @@ public:
 
     void printInfo();
     std::vector<int> getAction(SubHybridTSS *state, int epsilion);
+    std::vector<int> getAction(SubHybridTSS *state, int epsilion, std::mt19937& gen);
     void ConstructBaseline(const std::vector<Rule> &rules);
 
 

--- a/tests/hybrid_tss_test.cpp
+++ b/tests/hybrid_tss_test.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <chrono>
 #include <cstdint>
+#include <fstream>
 #include <string>
 #include <unistd.h>
 #include <utility>
@@ -34,6 +35,11 @@ static std::string MakeTempQTablePath() {
     const auto now = static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
     const uint64_t seq = counter.fetch_add(1, std::memory_order_relaxed);
     return "Data/test_qtable_" + std::to_string(getpid()) + "_" + std::to_string(now) + "_" + std::to_string(seq) + ".bin";
+}
+
+static std::vector<char> ReadBinaryFile(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::vector<char>(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
 }
 
 class TempFileGuard {
@@ -230,4 +236,38 @@ TEST_F(HybridTSSTest, TrainAndSaveThenLoadInferenceWorks) {
     }
     EXPECT_EQ(misclassified, 0);
 
+}
+
+TEST(HybridTSSDeterminismTest, SameSeedProducesIdenticalQTableArtifact) {
+    const std::vector<Rule> small_rules = {
+        MakeExactRule(40, 1, 0x01000000),
+        MakeExactRule(30, 2, 0x02000000),
+        MakeExactRule(20, 3, 0x03000000),
+        MakeExactRule(10, 4, 0x04000000),
+    };
+
+    TempFileGuard first_guard(MakeTempQTablePath());
+    TempFileGuard second_guard(MakeTempQTablePath());
+
+    HybridOptions opts;
+    opts.binth = 1;
+    opts.rtssleaf = 0.1;
+    opts.loop_num = 12;
+    opts.progress_step = 50;
+    opts.seed = 12345;
+    opts.qtable_out_path = first_guard.path();
+
+    HybridTSS first(opts);
+    std::string err;
+    ASSERT_TRUE(first.ConstructClassifierSafe(small_rules, &err)) << err;
+
+    opts.qtable_out_path = second_guard.path();
+    HybridTSS second(opts);
+    err.clear();
+    ASSERT_TRUE(second.ConstructClassifierSafe(small_rules, &err)) << err;
+
+    const auto first_qtable = ReadBinaryFile(first_guard.path());
+    const auto second_qtable = ReadBinaryFile(second_guard.path());
+    ASSERT_FALSE(first_qtable.empty());
+    EXPECT_EQ(first_qtable, second_qtable);
 }


### PR DESCRIPTION
## Summary
- Route HybridTSS training action selection through thread-local std::mt19937 instead of global rand()
- Make QTable merge order deterministic after parallel training
- Add a regression test that verifies same seed produces identical QTable artifacts

## Tests
- ctest --test-dir build --output-on-failure

Fixes #13