### PR TITLE
Harden packet trace parser

### DIFF
--- a/ElementaryClasses.h
+++ b/ElementaryClasses.h
@@ -20,6 +20,10 @@
 #include <chrono>
 #include <array>
 #include <climits>
+#include <cctype>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
 
 // base
 constexpr int RULE_SIZE      = 16;
@@ -253,9 +257,35 @@ inline std::vector<Packet> loadpacket(FILE* fp) {
     unsigned int proto_mask, fid;
     int number_pkt = 0; // number of packets
     std::vector<Packet> packets;
-    while (true) {
-        if (fscanf(fp, "%u %u %u %u %u %u %u\n", &header[0], &header[1], &header[2], &header[3], &header[4], &proto_mask, &fid) == Null)
-            break;
+    std::array<char, 1024> line{};
+    int line_number = 0;
+    while (std::fgets(line.data(), static_cast<int>(line.size()), fp)) {
+        line_number++;
+        const char* cursor = line.data();
+        while (*cursor && std::isspace(static_cast<unsigned char>(*cursor))) {
+            cursor++;
+        }
+        if (*cursor == '\0') {
+            continue;
+        }
+
+        int parsed_chars = 0;
+        int parsed_fields = std::sscanf(cursor, "%u %u %u %u %u %u %u %n",
+                                        &header[0], &header[1], &header[2], &header[3],
+                                        &header[4], &proto_mask, &fid, &parsed_chars);
+        if (parsed_fields != 7) {
+            throw std::runtime_error("Malformed packet trace line " + std::to_string(line_number) +
+                                     ": expected 7 fields, parsed " + std::to_string(parsed_fields));
+        }
+        cursor += parsed_chars;
+        while (*cursor && std::isspace(static_cast<unsigned char>(*cursor))) {
+            cursor++;
+        }
+        if (*cursor != '\0') {
+            throw std::runtime_error("Malformed packet trace line " + std::to_string(line_number) +
+                                     ": unexpected trailing data");
+        }
+
         Packet p;
         p.push_back(header[0]);
         p.push_back(header[1]);

--- a/tests/elementary_classes_test.cpp
+++ b/tests/elementary_classes_test.cpp
@@ -4,6 +4,8 @@
 #include "ElementaryClasses.h"
 #include <cstdio>
 #include <cstring>
+#include <stdexcept>
+#include <string>
 
 // ---------------------------------------------------------------------------
 // Rule construction
@@ -212,4 +214,23 @@ TEST_F(LoadPacketTest, FidFieldIsReasonable) {
 TEST(LoadPacketTest_Edge, NullFilePointerReturnsEmpty) {
     auto packets = loadpacket(nullptr);
     EXPECT_TRUE(packets.empty());
+}
+
+TEST(LoadPacketTest_Edge, IncompletePacketRowThrowsWithLineContext) {
+    FILE* fp = std::tmpfile();
+    ASSERT_NE(fp, nullptr);
+    fputs("1 2 3 4 5 6 7\n", fp);
+    fputs("8 9 10 11 12 13\n", fp);
+    rewind(fp);
+
+    try {
+        (void)loadpacket(fp);
+        FAIL() << "expected malformed packet trace to throw";
+    } catch (const std::runtime_error& err) {
+        const std::string message = err.what();
+        EXPECT_NE(message.find("line 2"), std::string::npos) << message;
+        EXPECT_NE(message.find("expected 7 fields"), std::string::npos) << message;
+    }
+
+    fclose(fp);
 }


### PR DESCRIPTION
## Summary
- parse packet traces line-by-line and require exactly 7 fields per row
- reject malformed rows with line-context errors instead of accepting partial data
- add a regression test for incomplete packet rows

## Tests
- cmake --build build
- ctest --test-dir build --output-on-failure

Closes #17